### PR TITLE
Remove some IOWriter methods to prevent invalidations

### DIFF
--- a/src/iowriter.jl
+++ b/src/iowriter.jl
@@ -39,12 +39,12 @@ end
 
 # Write methods
 Base.write(x::IOWriter, y::UInt8) = write(x.x, y)
-Base.write(x::IOWriter, data) = write(x.x, data)
-Base.write(x::IOWriter, data::Union{String, SubString{String}}) = write(x.x, data)
-Base.write(x::IOWriter, data::StridedArray) = write(x.x, data)
-Base.write(x::IOWriter, data::Char) = write(x.x, data)
-Base.write(x::IOWriter, data::Base.CodeUnits) = write(x.x, data.s)
-Base.write(x::IOWriter, x1, x2, xs...) = write(x.x, x1, x2, xs...)
+# Base.write(x::IOWriter, data) = write(x.x, data)
+# Base.write(x::IOWriter, data::Union{String, SubString{String}}) = write(x.x, data)
+# Base.write(x::IOWriter, data::StridedArray) = write(x.x, data)
+# Base.write(x::IOWriter, data::Char) = write(x.x, data)
+# Base.write(x::IOWriter, data::Base.CodeUnits) = write(x.x, data.s)
+# Base.write(x::IOWriter, x1, x2, xs...) = write(x.x, x1, x2, xs...)
 Base.unsafe_write(io::IOWriter, p::Ptr{UInt8}, n::UInt) = unsafe_write(io.x, p, n)
 
 Base.write(


### PR DESCRIPTION
These methods have reasonable fallbacks in Base, so the invalidations provide little gain.