### PR TITLE
Add doctests

### DIFF
--- a/src/BufferIO.jl
+++ b/src/BufferIO.jl
@@ -251,6 +251,29 @@ They may optionally implement
 """
 abstract type AbstractBufWriter end
 
+"""
+    get_buffer(io::AbstractBufReader)::ImmutableMemoryView{UInt8}
+
+Get the available bytes of `io`.
+
+Calling this function, even when the buffer is empty, should never do actual system I/O,
+and in particular should not attempt to fill the buffer.
+To fill the buffer, call [`fill_buffer`](@ref).
+
+# Examples
+```jldoctest
+julia> reader = BufReader(IOBuffer("abcdefghij"), 5);
+
+julia> get_buffer(reader) |> isempty
+true
+
+julia> fill_buffer(reader)
+5
+
+julia> get_buffer(reader) |> println
+UInt8[0x61, 0x62, 0x63, 0x64, 0x65]
+```
+"""
 function get_buffer end
 
 """
@@ -467,6 +490,23 @@ const PlainTypes = Union{PLAIN_TYPES...}
 Get a buffer with at least one byte, if bytes are available.
 Otherwise, call `grow_buffer`, then get the buffer again.
 Returns `nothing` if the buffer is still empty.
+
+# Examples
+```jldoctest
+julia> io = BufWriter(IOBuffer(), 12);
+
+julia> write_repeated(io, 0x00, 12)
+12
+
+julia> get_buffer(io) |> isempty
+true
+
+julia> get_nonempty_buffer(io) |> isempty
+false
+
+julia> get_buffer(io) |> isempty # buffer now grown
+false
+```
 """
 function get_nonempty_buffer(x::AbstractBufWriter)::Union{Nothing, MutableMemoryView{UInt8}}
     buffer = get_buffer(x)::MutableMemoryView{UInt8}

--- a/src/base.jl
+++ b/src/base.jl
@@ -4,6 +4,25 @@ Base.eof(x::AbstractBufReader) = isnothing(get_nonempty_buffer(x))
 
 Base.read(x::AbstractBufReader, ::Type{String}) = String(read(x))
 
+"""
+    read(io::AbstractBufReader)::Vector{UInt8}
+
+Read all of `io` into a new `Vector{UInt8}` and return the vector.
+
+This function repeatedly reads from `io` and resizes the vector until `io` reached EOF.
+If the filesize of `io` is known beforehand, calling `read(io, file_size)` may be faster.
+
+# Examples
+```jldoctest
+julia> v = read(CursorReader("hello"));
+
+julia> typeof(v) === Vector{UInt8}
+true
+
+julia> v == b"hello"
+true
+```
+"""
 function Base.read(x::AbstractBufReader)
     v = UInt8[]
     while true
@@ -16,17 +35,39 @@ function Base.read(x::AbstractBufReader)
 end
 
 """
-    read(io::AbstractBufReader, nb::Integer)
+    read(io::AbstractBufReader, nb::Integer)::Vector{UInt8}
 
 Read at exactly `nb` bytes from `io`, or until end of file, and return the
 bytes read as a `Vector{UInt8}`.
 
+This allocates a `Vector{UInt8}` of size `nb`, so do not pass a large
+value as `nb` in order to read the whole of `io`; use `read(io)` instead.
+
 Throw an `ArgumentError` if `nb` is negative.
+
+# Examples
+```jldoctest
+julia> io = CursorReader("hello, world!");
+
+julia> v = read(io, 8);
+
+julia> typeof(v) == Vector{UInt8}
+true
+
+julia> v == b"hello, w"
+true
+
+julia> read(io, 100) == b"orld!"
+true
+
+julia> isempty(read(io, 10))
+true
+```
 """
 function Base.read(x::AbstractBufReader, nb::Integer)
     nb = Int(nb)::Int
     nb < 0 && throw(ArgumentError("nb cannot be negative"))
-    v = UInt8[]
+    v = sizehint!(UInt8[], nb)
     remaining = nb
     while !iszero(remaining)
         buf = get_nonempty_buffer(x)::Union{Nothing, ImmutableMemoryView{UInt8}}
@@ -51,7 +92,7 @@ If `io` reached end of file, stop at EOF.
 
 Safety: The user must ensure that
 * The resulting pointer is valid, and points to at least `nbytes` of writeable memory.
-* `GC.@preserve`ing `cref` pins `ref` in memory, i.e. the pointer will not become
+* `GC.@preserve`ing `cref` correctly pins `ref` in memory, i.e. the pointer will not become
   invalid during the `GC.@preserve` block.
 """
 function Base.unsafe_read(x::AbstractBufReader, ref, n::UInt)::Int
@@ -90,6 +131,23 @@ end
 Read the available bytes of `io` to a new `Vector{UInt8}`, except if zero bytes
 are available. In that case, it will attempt to get more bytes exactly once.
 If still no bytes are available, `io` is EOF, and the resulting vector is empty.
+
+# Examples
+```jldoctest
+julia> io = BufReader(IOBuffer("hello, world!"), 10);
+
+julia> bytesavailable(io)
+0
+
+julia> readavailable(io) == b"hello, wor"
+true
+
+julia> readavailable(io) == b"ld!"
+true
+
+julia> readavailable(io) == b""
+true
+```
 """
 function Base.readavailable(x::AbstractBufReader)
     buf = get_nonempty_buffer(x)::Union{Nothing, ImmutableMemoryView{UInt8}}
@@ -104,6 +162,21 @@ end
 
 Get the next `UInt8` in `io`, without advancing `io`, or throw an `IOError`
 containing `IOErrorKinds.EOF` if `io` is EOF.
+
+# Examples
+```jldoctest
+julia> io = CursorReader("xyz");
+
+julia> peek(io) === UInt8('x')
+true
+
+julia> read(io) == b"xyz"
+true
+
+julia> peek(io)
+ERROR: End of file
+[...]
+```
 """
 function Base.peek(x::AbstractBufReader, ::Type{UInt8})
     buffer = get_buffer(x)::ImmutableMemoryView{UInt8}
@@ -123,6 +196,21 @@ end
 
 Get the next `UInt8` in `io`, or throw an `IOError` containing `IOErrorKinds.EOF`
 if `io` is EOF.
+
+# Examples
+```jldoctest
+julia> io = CursorReader("xy");
+
+julia> read(io, UInt8) === UInt8('x')
+true
+
+julia> read(io, UInt8) === UInt8('y')
+true
+
+julia> read(io, UInt8)
+ERROR: End of file
+[...]
+```
 """
 function Base.read(x::AbstractBufReader, ::Type{UInt8})
     res = peek(x, UInt8)
@@ -310,7 +398,7 @@ Throws an `ArgumentError` if `n < 0`.
 See also: [`skip_exact`](@ref)
 
 # Examples
-```
+```jldoctest
 julia> reader = CursorReader("abcdefghij");
 
 julia> skip(reader, 5)

--- a/src/bufreader.jl
+++ b/src/bufreader.jl
@@ -81,29 +81,6 @@ function BufReader(f, io::IO, buffer_size::Int = 8192)
     end
 end
 
-"""
-    get_buffer(io::AbstractBufReader)::ImmutableMemoryView{UInt8}
-
-Get the available bytes of `io`.
-
-Calling this function, even when the buffer is empty, should never do actual system I/O,
-and in particular should not attempt to fill the buffer.
-To fill the buffer, call [`fill_buffer`](@ref).
-
-# Examples
-```jldoctest
-julia> reader = BufReader(IOBuffer("abcdefghij"), 5);
-
-julia> get_buffer(reader) |> isempty
-true
-
-julia> fill_buffer(reader)
-5
-
-julia> get_buffer(reader) |> println
-UInt8[0x61, 0x62, 0x63, 0x64, 0x65]
-```
-"""
 function get_buffer(x::BufReader)::ImmutableMemoryView{UInt8}
     return @inbounds ImmutableMemoryView(x.buffer)[x.start:x.stop]
 end

--- a/src/bufwriter.jl
+++ b/src/bufwriter.jl
@@ -312,6 +312,21 @@ For writers with an underlying I/O, the underlying I/O should also be flushed.
 
 For writers without an underlying I/O, where the final writing destination is `io`
 ifself, the implementation may be simply `return nothing`.
+
+# Examples
+```jldoctest
+julia> buf = IOBuffer(); io = BufWriter(buf);
+
+julia> print(io, "hello")
+
+julia> String(take!(buf))
+""
+
+julia> flush(io)
+
+julia> String(take!(buf))
+"hello"
+```
 """
 function Base.flush(x::BufWriter)
     @inline shallow_flush(x)
@@ -347,12 +362,34 @@ Seeking should only change the filesize through its flush, so seeking an already
 stream should not change the filesize.
 
 If seeking to before the current position (as defined by `position`), data between
-the new and the previous position need not be changed, and the underlying file or IO
-need not immediately be truncated. However, new write operations should write (or
+the new and the previous position should not be changed, and the underlying file or IO
+should not immediately be truncated. However, new write operations should write (or
 overwrite) data at the new position.
 
 This method is not generically defined for `AbstractBufWriter`. Implementors of `seek`
 should also define `filesize(io)` and `position(io)`
+
+# Examples
+```jldoctest
+julia> buf = IOBuffer();
+
+julia> io = BufWriter(buf);
+
+julia> write(io, "abcdef");
+
+julia> seek(io, 3);
+
+julia> write(io, "xyzghi");
+
+julia> seek(io, 10)
+ERROR: Invalid seek, possibly seek out of bounds
+[...]
+
+julia> flush(io);
+
+julia> String(take!(buf))
+"abcxyzghi"
+```
 """
 function Base.seek(io::BufWriter, offset::Int)
     flush(io)
@@ -374,6 +411,22 @@ The filesize does not depend on, and does not include, the number of buffered an
 unflushed bytes.
 
 Types implementing `filesize` should also implement `seek` and `position`.
+
+# Examples
+```jldoctest
+julia> io = BufWriter(IOBuffer());
+
+julia> write(io, "abc");
+
+julia> filesize(io)
+0
+
+julia> flush(io); filesize(io)
+3
+
+julia> seek(io, 1); filesize(io)
+3
+```
 """
 Base.filesize(io::BufWriter) = filesize(io.io)
 
@@ -384,8 +437,23 @@ Get the zero-based stream position.
 
 If the stream position is `p` (zero-based), then the next byte written will be byte number
 `p + 1` (one-based) in the file.
-The stream position does account for buffered (consumed, but unflushed) bytes, and therefore may exceed `filesize`.
+The stream position *does* account for buffered (consumed, but unflushed) bytes, and therefore may exceed `filesize`.
 After calling `flush`, `position` must be in `0:filesize(io)`, if `filesize` is defined.
+
+# Examples
+```jldoctest
+julia> io = BufWriter(IOBuffer());
+
+julia> write(io, "hello");
+
+julia> (filesize(io), position(io))
+(0, 5)
+
+julia> seek(io, 2); # NB: seek flushes
+
+julia> (filesize(io), position(io))
+(5, 2)
+```
 """
 Base.position(io::BufWriter) = position(io.io) + io.consumed
 

--- a/src/lineiterator.jl
+++ b/src/lineiterator.jl
@@ -161,6 +161,19 @@ Unlike `eachline(::IO)`, this method does not close `io` when iteration is done,
 yet support `Iterators.reverse` or `last`.
 
 See also: [`line_views`](@ref)
+
+# Examples
+```jldoctest
+julia> io = CursorReader("hello\\nthere\\n\\nGeneral!");
+
+julia> lines = collect(eachline(io)); println(lines)
+["hello", "there", "", "General!"]
+
+julia> typeof(lines) == Vector{String}
+true
+
+julia> close(io);
+```
 """
 function Base.eachline(x::AbstractBufReader; keep::Bool = false)
     return EachLine{typeof(x)}(line_views(x; chomp = !keep))

--- a/test/generic_reader.jl
+++ b/test/generic_reader.jl
@@ -84,7 +84,7 @@ end
     @test_throws ArgumentError read(io, -1)
 
     io = GenericBufReader("abcde")
-    @test read(io, typemax(Int)) == b"abcde"
+    @test read(io, 500) == b"abcde"
 end
 
 @testset "read(::T, String)" begin


### PR DESCRIPTION
Add more doctests. Clarify two semantics:
* `read(::AbstractBufReader, x::Int)` will allocate a vector of length `x`.
* Seeking backwards with an AbstractBufWriter should not truncate

